### PR TITLE
added empty gres.conf and instruction to copy it into the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ RUN set -ex \
     && git config --global push.default simple
 
 COPY slurm.conf /etc/slurm/slurm.conf
+COPY gres.conf /etc/slurm/gres.conf
 COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
 COPY supervisord.conf /etc/
 

--- a/gres.conf
+++ b/gres.conf
@@ -1,0 +1,2 @@
+Name=gpu Type=titanxp Cores=0
+Name=gpu Type=titanxp Cores=1

--- a/gres.conf
+++ b/gres.conf
@@ -1,2 +1,1 @@
 Name=gpu Type=titanxp Cores=0
-Name=gpu Type=titanxp Cores=1

--- a/slurm.conf
+++ b/slurm.conf
@@ -87,7 +87,9 @@ AccountingStorageType=accounting_storage/slurmdbd
 #AccountingStorageUser=
 #
 # COMPUTE NODES
-NodeName=c[1-10] NodeHostName=localhost NodeAddr=127.0.0.1 RealMemory=1000
+GresTypes=gpu
+NodeName=c[1-5] NodeHostName=localhost NodeAddr=127.0.0.1 RealMemory=1000
+NodeName=c[6-10] NodeHostName=localhost NodeAddr=127.0.0.1 RealMemory=1000 Gres=gpu:titanxp:1
 #
 # PARTITIONS
 PartitionName=normal Default=yes Nodes=c[1-5] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=5 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP


### PR DESCRIPTION
@giovtorres this is simply a wonderful repo. Thanks for sharing it. We have started to evaluate if using your repo could facilitate debuggin our slurm installation? On that note, I added an empty `gres.conf` file which is copied into the container(s). I played around with it to emulate GPU-enabled nodes. It appears to work. If you find this contribution useful, I could add more to this PR as I might research into running your setup with nvidia-docker (so that the GPU handthrough works). 