### PR TITLE
docker-entrypoint: create cluster before starting

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,4 +52,28 @@ chown slurm:slurm /var/spool/slurmd /var/run/slurmd /var/lib/slurmd /var/log/slu
 echo "- Starting all Slurm processes under supervisord"
 /usr/bin/supervisord --configuration /etc/supervisord.conf
 
+# The following is not needed in slurm > 20.02 (the cluster is created
+# automatically if it doesn't exist)
+echo "Slurm daemons are starting up..."
+for count in {30..0}; do
+    if supervisorctl status | grep -v RUNNING > /dev/null; then
+        sleep 1
+    else
+        break
+    fi
+done
+if [[ "$count" -eq 0 ]]; then
+    echo >&2 "Daemons did not start"
+    exit 1
+fi
+
+# Give a few more seconds for daemons to actually become responsive.
+echo "Slurm is initializing..."
+sleep 5
+echo "Creating cluster..."
+yes | sacctmgr add cluster linux > /dev/null
+supervisorctl restart slurmctld > /dev/null
+# Ensure slurmctld becomes responsive again
+sleep 3
+
 exec "$@"


### PR DESCRIPTION
This makes the Slurm accounting database work (we had to run the command sacctmgr add cluster $CLUSTERNAME).  According to [the Slurm docs](https://slurm.schedmd.com/accounting.html#database-configuration), this is only needed in Slurm < 20.02, so maybe it's better to close this and upgrade Slurm instead.  

However, if you do upgrade to slurm >=20.02, note that we found several race conditions where the daemons didn't start up on time / in the right order (mysql was apparently not fully killed, so it took another few seconds for supervisord to bring everything into the RUNNING state).  This may be less of a concern with when the cluster gets automatically added, but from what I just discovered there might still be some issues.

- Slurm < 20.02 requires `sacctmgr add cluster linux` to be run in
  order to add the cluster to the accounting database.
- This is a slightly long process to do this, but there are many
  errors that can occur if not all daemons are started yet, and we
  can't easily wait for all of them.