### PR TITLE
feat: support Python 3.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,8 @@ RUN set -ex \
         munge \
         munge-devel \
         ncurses-devel \
-        openssl-devel \
-        openssl-libs \
-        perl \
+        patch \
+        perl-core \
         pkgconfig \
         psmisc \
         readline-devel \
@@ -74,10 +73,27 @@ ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
+# Install OpenSSL1.1.1
+# See PEP 644: https://www.python.org/dev/peps/pep-0644/
+ARG OPENSSL_VERSION="1.1.1l"
+RUN set -ex \
+    && wget --quiet https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && tar xzf openssl-${OPENSSL_VERSION}.tar.gz \
+    && pushd openssl-${OPENSSL_VERSION} \
+    && ./config --prefix=/opt/openssl --openssldir=/etc/ssl \
+    && make \
+    && make test \
+    && make install \
+    && echo "/opt/openssl/lib" >> /etc/ld.so.conf.d/openssl.conf \
+    && ldconfig \
+    && popd \
+    && rm -rf openssl-${OPENSSL_VERSION}.tar.gz
+
 # Install supported Python versions and install dependencies.
 # Set the default global to the latest supported version.
 # Use pyenv inside the container to switch between Python versions.
-ARG PYTHON_VERSIONS="3.6.15 3.7.12 3.8.12 3.9.9"
+ARG PYTHON_VERSIONS="3.6.15 3.7.12 3.8.12 3.9.9 3.10.0"
+ARG CONFIGURE_OPTS="--with-openssl=/opt/openssl"
 RUN set -ex \
     && curl https://pyenv.run | bash \
     && echo "eval \"\$(pyenv init --path)\"" >> "${HOME}/.bashrc" \

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ container runs the following processes:
 It also has the following Python versions installed using
 [pyenv](https://github.com/pyenv/pyenv):
 
-* Python 3.6.15
-* Python 3.7.12
-* Python 3.8.12
-* Python 3.9.9
+* 3.6.15
+* 3.7.12
+* 3.8.12
+* 3.9.9
+* 3.10.0
 
 ## Usage
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3,7 +3,7 @@
 import pytest
 
 TINI_VERSION = "0.18.0"
-PYTHON_VERSIONS = ["3.6.15", "3.7.12", "3.8.12", "3.9.9"]
+PYTHON_VERSIONS = ["3.6.15", "3.7.12", "3.8.12", "3.9.9", "3.10.0"]
 SLURM_VERSION = "21.08.0"
 
 MARIADB_PORT = 3306


### PR DESCRIPTION
This change adds OpenSSL 1.1.1 to support Python 3.10.0. It is also used to build all supported versions of Python. See [PEP 664](https://www.python.org/dev/peps/pep-0644/).