### PR TITLE
fix: use git236 instead of git224

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex \
         gcc \
         gcc-c++ \
         gdbm-devel \
-        git224 \
+        git236 \
         glibc-devel \
         gmp-devel \
         libffi-devel \


### PR DESCRIPTION
git224 does not exist anymore in the IUS repo.