### PR TITLE
slurm 22.05 support and multiple-slurmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,13 +71,16 @@ RUN set -ex \
     && git config --global push.default simple
 
 # Add Tini
-ENV TINI_VERSION v0.18.0
+ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
+RUN gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+ && gpg --batch --verify /tini.asc /tini
 RUN chmod +x /tini
 
 # Install OpenSSL1.1.1
 # See PEP 644: https://www.python.org/dev/peps/pep-0644/
-ARG OPENSSL_VERSION="1.1.1l"
+ARG OPENSSL_VERSION="1.1.1s"
 RUN set -ex \
     && wget --quiet https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && tar xzf openssl-${OPENSSL_VERSION}.tar.gz \
@@ -89,12 +92,12 @@ RUN set -ex \
     && echo "/opt/openssl/lib" >> /etc/ld.so.conf.d/openssl.conf \
     && ldconfig \
     && popd \
-    && rm -rf openssl-${OPENSSL_VERSION}.tar.gz
+    && rm -f openssl-${OPENSSL_VERSION}.tar.gz
 
 # Install supported Python versions and install dependencies.
 # Set the default global to the latest supported version.
 # Use pyenv inside the container to switch between Python versions.
-ARG PYTHON_VERSIONS="3.6.15 3.7.12 3.8.12 3.9.9 3.10.0"
+ARG PYTHON_VERSIONS="3.6.15 3.7.16 3.8.16 3.9.16 3.10.9 3.11.1"
 ARG CONFIGURE_OPTS="--with-openssl=/opt/openssl"
 RUN set -ex \
     && curl https://pyenv.run | bash \
@@ -110,7 +113,7 @@ RUN set -ex \
         done
 
 # Compile, build and install Slurm from Git source
-ARG SLURM_TAG=slurm-21-08-8-2
+ARG SLURM_TAG=slurm-22-05-7-1
 ARG JOBS=4
 RUN set -ex \
     && git clone -b ${SLURM_TAG} --single-branch --depth=1 https://github.com/SchedMD/slurm.git \
@@ -139,9 +142,9 @@ RUN set -ex \
     && /sbin/create-munge-key
 
 RUN dd if=/dev/random of=/etc/slurm/jwt_hs256.key bs=32 count=1 \
-    && chmod 600 /etc/slurm/jwt_hs256.key && chown slurm.slurm /etc/slurm/jwt_hs256.key
+    && chmod 600 /etc/slurm/jwt_hs256.key && chown slurm:slurm /etc/slurm/jwt_hs256.key
 
-COPY --chown=slurm files/slurm/slurm.conf files/slurm/gres.conf files/slurm/slurmdbd.conf /etc/slurm/
+COPY --chown=slurm files/slurm/slurm.conf files/slurm/gres.conf files/slurm/slurmdbd.conf files/slurm/cgroup.conf /etc/slurm/
 COPY files/supervisord.conf /etc/
 
 RUN chmod 0600 /etc/slurm/slurmdbd.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,13 +113,13 @@ RUN set -ex \
         done
 
 # Compile, build and install Slurm from Git source
-ARG SLURM_TAG=slurm-22-05-7-1
+ARG SLURM_TAG=slurm-22-05-8-1
 ARG JOBS=4
 RUN set -ex \
     && git clone -b ${SLURM_TAG} --single-branch --depth=1 https://github.com/SchedMD/slurm.git \
     && pushd slurm \
     && ./configure --prefix=/usr --sysconfdir=/etc/slurm --enable-slurmrestd \
-        --with-mysql_config=/usr/bin --libdir=/usr/lib64 \
+        --with-mysql_config=/usr/bin --libdir=/usr/lib64 --enable-multiple-slurmd \
     && sed -e 's|#!/usr/bin/env python3|#!/usr/bin/python|' -i doc/html/shtml2html.py \
     && make -j ${JOBS} install \
     && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
@@ -144,7 +144,7 @@ RUN set -ex \
 RUN dd if=/dev/random of=/etc/slurm/jwt_hs256.key bs=32 count=1 \
     && chmod 600 /etc/slurm/jwt_hs256.key && chown slurm:slurm /etc/slurm/jwt_hs256.key
 
-COPY --chown=slurm files/slurm/slurm.conf files/slurm/gres.conf files/slurm/slurmdbd.conf files/slurm/cgroup.conf /etc/slurm/
+COPY --chown=slurm files/slurm/slurm.conf files/slurm/slurmdbd.conf files/slurm/cgroup.conf /etc/slurm/
 COPY files/supervisord.conf /etc/
 
 RUN chmod 0600 /etc/slurm/slurmdbd.conf

--- a/files/slurm/cgroup.conf
+++ b/files/slurm/cgroup.conf
@@ -1,0 +1,4 @@
+CgroupAutomount=yes
+CgroupPlugin=cgroup/v1
+ConstrainCores=no
+ConstrainRAMSpace=no

--- a/files/slurm/gres.conf
+++ b/files/slurm/gres.conf
@@ -1,2 +1,0 @@
-Name=gpu Type=titanxp Count=3 Cores=0
-Name=gpu Type=a100 Count=3 Cores=0

--- a/files/slurm/gres.conf
+++ b/files/slurm/gres.conf
@@ -1,1 +1,2 @@
-Name=gpu Type=titanxp Cores=0
+Name=gpu Type=titanxp Count=3 Cores=0
+Name=gpu Type=a100 Count=3 Cores=0

--- a/files/slurm/slurm.conf
+++ b/files/slurm/slurm.conf
@@ -54,14 +54,10 @@ KillWait=30
 MinJobAge=300
 MpiDefault=none
 #MpiParams=ports=#-#
-NodeName=c1 NodeHostName=slurmctl NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56
-NodeName=c2 NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56 Gres=gpu:titanxp:3,gpu:a100:3
-NodeName=c3 NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56 Gres=gpu:titanxp:3,gpu:a100:3 Gres=gpu:titanxp:3
-NodeName=c4 NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56 Gres=gpu:titanxp:3,gpu:a100:3 Gres=gpu:a100:3
+NodeName=node[001-003] NodeHostName=slurmctl NodeAddr=127.0.0.1 Port=[7000-7002] Sockets=2 CoresPerSocket=28 RealMemory=549756
 #OverTimeLimit=0
-PartitionName=debug Nodes=c[3-4] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
-PartitionName=normal Default=yes Nodes=c[1-2] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
 # PARTITIONS
+PartitionName=normal Default=yes Nodes=node[001-003] Priority=50 DefMemPerCPU=500 Shared=NO MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
 #PluginDir=
 #PlugStackConfig=
 # POWER SAVE SUPPORT FOR IDLE NODES (optional)
@@ -103,11 +99,11 @@ SlurmctldPidFile=/var/run/slurm/slurmctld.pid
 SlurmctldPort=6817
 SlurmctldTimeout=120
 SlurmdDebug=debug
-SlurmdLogFile=/var/log/slurm/slurmd.log
+SlurmdLogFile=/var/log/slurm/slurmd-%n.log
 SlurmdParameters=config_overrides
-SlurmdPidFile=/var/run/slurm/slurmd.pid
+SlurmdPidFile=/var/run/slurm/slurmd-%n.pid
 SlurmdPort=6818
-SlurmdSpoolDir=/var/spool/slurmd
+SlurmdSpoolDir=/var/spool/slurmd/%n
 SlurmdTimeout=300
 #SlurmdUser=root
 #SlurmSchedLogFile=

--- a/files/slurm/slurm.conf
+++ b/files/slurm/slurm.conf
@@ -3,6 +3,7 @@
 #AccountingStoragePass=
 #AccountingStoragePort=
 AccountingStorageType=accounting_storage/slurmdbd
+AccountingStorageTRES=gres/gpu,gres/gpu:titanxp,gres/gpu:a100
 #AccountingStorageUser=
 #AccountingStoreFlags=
 #BatchStartTimeout=10
@@ -53,10 +54,10 @@ KillWait=30
 MinJobAge=300
 MpiDefault=none
 #MpiParams=ports=#-#
-NodeName=c1 NodeHostName=slurmctl NodeAddr=127.0.0.1 RealMemory=1000
-NodeName=c2 NodeAddr=127.0.0.1 RealMemory=1000
-NodeName=c3 NodeAddr=127.0.0.1 RealMemory=1000 Gres=gpu:titanxp:1
-NodeName=c4 NodeAddr=127.0.0.1 RealMemory=1000 Gres=gpu:titanxp:1
+NodeName=c1 NodeHostName=slurmctl NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56
+NodeName=c2 NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56 Gres=gpu:titanxp:3,gpu:a100:3
+NodeName=c3 NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56 Gres=gpu:titanxp:3,gpu:a100:3 Gres=gpu:titanxp:3
+NodeName=c4 NodeAddr=127.0.0.1 RealMemory=549756 Sockets=2 CoresPerSocket=56 Gres=gpu:titanxp:3,gpu:a100:3 Gres=gpu:a100:3
 #OverTimeLimit=0
 PartitionName=debug Nodes=c[3-4] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
 PartitionName=normal Default=yes Nodes=c[1-2] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
@@ -103,6 +104,7 @@ SlurmctldPort=6817
 SlurmctldTimeout=120
 SlurmdDebug=debug
 SlurmdLogFile=/var/log/slurm/slurmd.log
+SlurmdParameters=config_overrides
 SlurmdPidFile=/var/run/slurm/slurmd.pid
 SlurmdPort=6818
 SlurmdSpoolDir=/var/spool/slurmd

--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -46,7 +46,6 @@ priority=2
 
 [program:slurmdbd]
 user=root
-#command=/bin/bash -c "until echo 'SELECT 1' | mysql -h localhost -uslurm -ppassword &> /dev/null; do echo 'Waiting for DB'; sleep 1; done && /usr/sbin/slurmdbd -Dvvv"
 command=/usr/sbin/slurmdbd -Dvvv
 autostart=false
 autorestart=false
@@ -61,7 +60,6 @@ priority=10
 
 [program:slurmctld]
 user=root
-#command=/bin/bash -c "until 2>/dev/null >/dev/tcp/localhost/6819; do echo 'Waiting for port 6819'; sleep 1; done && /usr/sbin/slurmctld -Dvvv"
 command=/usr/sbin/slurmctld -Dvvv
 autostart=false
 autorestart=false
@@ -76,8 +74,7 @@ priority=50
 
 [program:slurmd]
 user=root
-#command=/bin/bash -c "until 2>/dev/null >/dev/tcp/localhost/6817; do echo 'Waiting for port 6817'; sleep 1; done && /usr/sbin/slurmd -Dvvv"
-command=/usr/sbin/slurmd -Dvvv
+command=/usr/sbin/slurmd -Dvvv -N node%(process_num)03d
 autostart=false
 autorestart=false
 exitcodes=0,1,2
@@ -88,6 +85,9 @@ stderr_logfile=/var/log/supervisor/slurmd.log
 stderr_logfile_maxbytes=1MB
 stderr_logfile_backups=5
 priority=100
+process_name=node%(process_num)03d
+numprocs=%(ENV_SLURM_NODE_COUNT)s
+numprocs_start=1
 
 [program:slurmrestd]
 user=root


### PR DESCRIPTION
## Version updates

- update some versions for `openssl`, `tini` and `python`
- update slurm to 22.05

## Multiple node support

Compiles slurm with `--multiple-slurmd`. Without this option, you cannot correctly operate multiple nodes on a single host. Multiple nodes were previously configured in the slurm.conf, but this was always yielding lots of errors (even though it appeared to be working when requesting the nodes). But doing something like `srun` in a multi-node job would always fail - which now works correctly with `--multiple-slurmd`.

Therefore `supervisord.conf` has also been adapted to start, by default, 3 instances of `slurmds`.

## Changes is the entrypoint file

- removed the check_port_status thing. Don't really see a specific use case for it.
- remove the check_running_status function. when doing `supervisorctl start`, it will already report whether the service has started or failed. No need to repeatedly spam the state.

## Other changes

`gres.conf` and the GPUs attached to the nodes have been removed for now - same reason as above with the multiple nodes - You can request it, but it will probably yield some errors, since there is no GPU device file available (maybe need to do some more testing and perhaps could add it back later)

`cgroup.conf` has been added, with explicity setting the cgroup version to be used to v1. Without it, slurm did not want to start.

Also enable `config_overrides` in the slurm.conf for the slurmd, so we can declare an arbitrary amount of resources for the node, e.g 56 CPUs and 512GB of RAM, even though it isn't physically available.