### PR TITLE
fix: Bump OpenSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN chmod +x /tini
 
 # Install OpenSSL1.1.1
 # See PEP 644: https://www.python.org/dev/peps/pep-0644/
-ARG OPENSSL_VERSION="1.1.1l"
+ARG OPENSSL_VERSION="1.1.1s"
 RUN set -ex \
     && wget --quiet https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && tar xzf openssl-${OPENSSL_VERSION}.tar.gz \


### PR DESCRIPTION
With 1.1.1l there were build errors. This change was first proposed in https://github.com/giovtorres/docker-centos7-slurm/pull/49 by @tazend, but that also included other features.

FWIW, the reason I needed to rebuild was to override some `slurm.conf` which @tazend has added an interface for, so big +1 on that :)

With `main` I had the following output when building the container:

```
Test Summary Report                                                                                                                   	 
-------------------                                                                                                                   	 
../test/recipes/80-test_cms.t                	(Wstat: 1280 Tests: 6 Failed: 5)                                                     	 
  Failed tests:  1-5                                                                                                                  	 
  Non-zero exit status: 5                                                                                                             	 
../test/recipes/80-test_ssl_new.t            	(Wstat: 256 Tests: 29 Failed: 1)                                                     	 
  Failed test:  12                                                                                                                    	 
  Non-zero exit status: 1                                                                                                             	 
Files=158, Tests=2636, 75 wallclock secs ( 1.97 usr  0.24 sys + 64.14 cusr 18.56 csys = 84.91 CPU)                                    	 
Result: FAIL                                                                                                                          	 
make[1]: *** [_tests] Error 1                                                                                                         	 
make[1]: Leaving directory `/openssl-1.1.1l'                                                                                          	 
make: *** [tests] Error 2                                                                                                             	 
Error: building at STEP "RUN set -ex 	&& wget --quiet https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz 	&& tar xzf op
enssl-${OPENSSL_VERSION}.tar.gz 	&& pushd openssl-${OPENSSL_VERSION} 	&& ./config --prefix=/opt/openssl --openssldir=/etc/ssl 	&&
make 	&& make test 	&& make install 	&& echo "/opt/openssl/lib" >> /etc/ld.so.conf.d/openssl.conf 	&& ldconfig 	&& popd	 
&& rm -rf openssl-${OPENSSL_VERSION}.tar.gz": while running runtime: exit status 2
```

With this change, the rebuild completes successfully.