### PR TITLE
Update deprecated actions for Node16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version}}
 


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

I saw a deprecation warning on the GitHub Actions page

![Screenshot from 2023-11-07 09-26-22](https://github.com/giovtorres/docker-centos7-slurm/assets/1028657/d6b897ef-4826-47ed-b6e4-60923a83ab93)
